### PR TITLE
Rename LambdaExample to SporeExample

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Sample
       run: |
         sbt -v "sampleJVM / runMain spores.sample.BuilderExample"
-        sbt -v "sampleJVM / runMain spores.sample.LambdaExample"
+        sbt -v "sampleJVM / runMain spores.sample.SporeExample"
         sbt -v "sampleJVM / runMain spores.sample.AutoCaptureExample"
         sbt -v "sampleJVM / runMain spores.sample.AgentMain"
         sbt -v "sampleJVM / runMain spores.sample.Futures"

--- a/sample/jvm/src/main/scala/spores/sample/SporeExample.scala
+++ b/sample/jvm/src/main/scala/spores/sample/SporeExample.scala
@@ -5,7 +5,7 @@ import spores.given
 import spores.sample.platform.*
 
 
-object LambdaExample {
+object SporeExample {
 
   val Lambda1 = Spore.apply[Int => String] { x => x.toString.reverse }
 


### PR DESCRIPTION
This is better as the file has examples of the `Spore.apply` factory. The name `Lambda` comes from a previous version and is now outdated.