### PR TITLE
Add default package for easy imports

### DIFF
--- a/core/jvm/src/test/scala/spores/jvm/AutoCaptureErrorTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/AutoCaptureErrorTests.scala
@@ -7,8 +7,8 @@ import org.junit.Assert.*
 
 import upickle.default.*
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.TestUtils.*
 
 

--- a/core/jvm/src/test/scala/spores/jvm/AutoCaptureTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/AutoCaptureTests.scala
@@ -7,8 +7,8 @@ import org.junit.Assert.*
 
 import upickle.default.*
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.TestUtils.*
 
 

--- a/core/jvm/src/test/scala/spores/jvm/SporeLambdaErrorTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/SporeLambdaErrorTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 // // The following code should produce a compile error:

--- a/core/jvm/src/test/scala/spores/jvm/SporeLambdaTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/SporeLambdaTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeLambdaTests:

--- a/core/jvm/src/test/scala/spores/test/SporeTests.scala
+++ b/core/jvm/src/test/scala/spores/test/SporeTests.scala
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import spores.Spore
-import spores.given
+import spores.default.given
 
 
 @RunWith(classOf[JUnit4])

--- a/core/jvm/src/test/scala/spores/test/TrieMapTest.scala
+++ b/core/jvm/src/test/scala/spores/test/TrieMapTest.scala
@@ -6,7 +6,8 @@ import org.junit.runners.JUnit4
 
 import scala.collection.concurrent.TrieMap
 
-import spores.{Duplicable, Duplicate}
+import spores.default.*
+import spores.default.given
 
 
 case class Customer(name: String, customerNo: Int)
@@ -33,7 +34,7 @@ class TrieMapTest {
       val sumAges = infos.foldLeft(0)(_ + _.age).toFloat
       if (infos.size == 0) 0
       else sumAges / infos.size
-    }.unwrap()
+    }
 
     val res = s(List())
     assert(res == 0)

--- a/core/shared/src/main/scala/spores/Conversions.scala
+++ b/core/shared/src/main/scala/spores/Conversions.scala
@@ -1,0 +1,22 @@
+package spores
+
+/** A collection of conversions. Contains conversions from `Spore[Function1[T1,
+  * R]]` to `Function1[T1, R]` etc..
+  */
+object Conversions {
+
+  given conversionSporeToFunction0[R]: Conversion[Spore[() => R], (() => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction1[T1, R]: Conversion[Spore[T1 => R], (T1 => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction2[T1, T2, R]: Conversion[Spore[(T1, T2) => R], ((T1, T2) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction3[T1, T2, T3, R]: Conversion[Spore[(T1, T2, T3) => R], ((T1, T2, T3) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction4[T1, T2, T3, T4, R]: Conversion[Spore[(T1, T2, T3, T4) => R], ((T1, T2, T3, T4) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction5[T1, T2, T3, T4, T5, R]: Conversion[Spore[(T1, T2, T3, T4, T5) => R], ((T1, T2, T3, T4, T5) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction6[T1, T2, T3, T4, T5, T6, R]: Conversion[Spore[(T1, T2, T3, T4, T5, T6) => R], ((T1, T2, T3, T4, T5, T6) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction7[T1, T2, T3, T4, T5, T6, T7, R]: Conversion[Spore[(T1, T2, T3, T4, T5, T6, T7) => R], ((T1, T2, T3, T4, T5, T6, T7) => R)] = { spore => spore.unwrap() }
+
+  // Conversions for context functions are not supported:
+  // > Implementation restriction: cannot convert this expression to
+  // > `Conversion[spores.Spore[(T1) ?=> R], (T1) ?=> R]` because its result
+  // > type `(T1) ?=> R` is a contextual function type.
+
+}

--- a/core/shared/src/main/scala/spores/Conversions.scala
+++ b/core/shared/src/main/scala/spores/Conversions.scala
@@ -19,4 +19,13 @@ object Conversions {
   // > `Conversion[spores.Spore[(T1) ?=> R], (T1) ?=> R]` because its result
   // > type `(T1) ?=> R` is a contextual function type.
 
+  given conversionDuplicateToFunction0[R]: Conversion[Duplicate[() => R], (() => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction1[T1, R]: Conversion[Duplicate[T1 => R], (T1 => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction2[T1, T2, R]: Conversion[Duplicate[(T1, T2) => R], ((T1, T2) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction3[T1, T2, T3, R]: Conversion[Duplicate[(T1, T2, T3) => R], ((T1, T2, T3) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction4[T1, T2, T3, T4, R]: Conversion[Duplicate[(T1, T2, T3, T4) => R], ((T1, T2, T3, T4) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction5[T1, T2, T3, T4, T5, R]: Conversion[Duplicate[(T1, T2, T3, T4, T5) => R], ((T1, T2, T3, T4, T5) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction6[T1, T2, T3, T4, T5, T6, R]: Conversion[Duplicate[(T1, T2, T3, T4, T5, T6) => R], ((T1, T2, T3, T4, T5, T6) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction7[T1, T2, T3, T4, T5, T6, T7, R]: Conversion[Duplicate[(T1, T2, T3, T4, T5, T6, T7) => R], ((T1, T2, T3, T4, T5, T6, T7) => R)] = { dup => dup.unwrap() }
+
 }

--- a/core/shared/src/main/scala/spores/Spore.scala
+++ b/core/shared/src/main/scala/spores/Spore.scala
@@ -139,37 +139,6 @@ sealed trait Spore[+T] {
       case PackedWithCtx(packed, packedEnv) => packed.unwrap()(using packedEnv.unwrap())
   }
 
-  def apply[R]()(using ev: T <:< (() => R)): R = {
-    this.unwrap().apply()
-  }
-
-  def apply[T1, R](arg1: T1)(using ev: T <:< (T1 => R)): R = {
-    this.unwrap().apply(arg1)
-  }
-
-  def apply[T1, T2, R](arg1: T1, arg2: T2)(using ev: T <:< ((T1, T2) => R)): R = {
-    this.unwrap().apply(arg1, arg2)
-  }
-
-  def apply[T1, T2, T3, R](arg1: T1, arg2: T2, arg3: T3)(using ev: T <:< ((T1, T2, T3) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3)
-  }
-
-  def apply[T1, T2, T3, T4, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4)(using ev: T <:< ((T1, T2, T3, T4) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4)
-  }
-
-  def apply[T1, T2, T3, T4, T5, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5)(using ev: T <:< ((T1, T2, T3, T4, T5) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4, arg5)
-  }
-
-  def apply[T1, T2, T3, T4, T5, T6, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6)(using ev: T <:< ((T1, T2, T3, T4, T5, T6) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4, arg5, arg6)
-  }
-
-  def apply[T1, T2, T3, T4, T5, T6, T7, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7)(using ev: T <:< ((T1, T2, T3, T4, T5, T6, T7) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-  }
 }
 
 

--- a/core/shared/src/main/scala/spores/default.scala
+++ b/core/shared/src/main/scala/spores/default.scala
@@ -1,0 +1,15 @@
+package spores
+
+package object default {
+
+  export spores.Spore
+  export spores.SporeBuilder
+  export spores.SporeClassBuilder
+  export spores.Env
+  export spores.Duplicable
+  export spores.Duplicable.given
+  export spores.Duplicate
+  export spores.ReadWriters.given
+  export spores.Conversions.given
+
+}

--- a/core/shared/src/main/scala/spores/default.scala
+++ b/core/shared/src/main/scala/spores/default.scala
@@ -8,6 +8,7 @@ package object default {
   export spores.Env
   export spores.Duplicable
   export spores.Duplicable.given
+  export spores.Duplicable.duplicate
   export spores.Duplicate
   export spores.ReadWriters.given
   export spores.Conversions.given

--- a/core/shared/src/main/scala/spores/package.scala
+++ b/core/shared/src/main/scala/spores/package.scala
@@ -5,8 +5,4 @@
   * Create a Spore using the factories in [[spores.Spore]], or by using the
   * [[spores.SporeBuilder]] or [[spores.SporeClassBuilder]].
   */
-package object spores {
-
-  export spores.ReadWriters.given
-
-}
+package object spores

--- a/core/shared/src/test/scala/spores/SporeClassBuilderErrorTests.scala
+++ b/core/shared/src/test/scala/spores/SporeClassBuilderErrorTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeClassBuilderErrorTests:

--- a/core/shared/src/test/scala/spores/SporeClassBuilderTests.scala
+++ b/core/shared/src/test/scala/spores/SporeClassBuilderTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeClassBuilderTests:

--- a/core/shared/src/test/scala/spores/SporeObjectBuilderErrorTests.scala
+++ b/core/shared/src/test/scala/spores/SporeObjectBuilderErrorTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeBuilderErrorTests:

--- a/core/shared/src/test/scala/spores/SporeObjectBuilderTests.scala
+++ b/core/shared/src/test/scala/spores/SporeObjectBuilderTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeBuilderTests:

--- a/core/shared/src/test/scala/spores/test/DuplicableTests.scala
+++ b/core/shared/src/test/scala/spores/test/DuplicableTests.scala
@@ -5,8 +5,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import spores.Duplicable.duplicate
-import spores.Duplicate
+import spores.default.*
+import spores.default.given
 
 
 class C {
@@ -42,7 +42,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val res = b2.unwrap()()
+    val res = b2()
     assert(res == 6)
   }
 
@@ -57,7 +57,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val res = b2.unwrap()()
+    val res = b2()
     assert(res == 5)
 
     val dup = b.asInstanceOf[DuplicateWithEnv[C, Int]]
@@ -76,7 +76,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val envVal = b2.unwrap()()
+    val envVal = b2()
 
     assert(envVal != x)
   }
@@ -92,7 +92,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val envVal = b2.unwrap()()
+    val envVal = b2()
 
     assert(envVal.f == 7)
     assert(envVal ne x)
@@ -109,7 +109,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val envVal = b2.unwrap()()
+    val envVal = b2()
 
     assert(envVal.f == 7)
     assert(envVal ne x)
@@ -122,7 +122,7 @@ class DuplicableTests {
       (x: Int) => x + 2
     }
     val s2 = duplicate(s)
-    val res = s2.unwrap()(3)
+    val res = s2(3)
     assert(res == 5)
   }
 
@@ -136,7 +136,7 @@ class DuplicableTests {
     }
 
     val b2 = duplicate(b)
-    val res = b2.unwrap()(3)
+    val res = b2(3)
     assert(res == 7)
   }
 
@@ -145,7 +145,7 @@ class DuplicableTests {
     def duplicateThenApply[T, R, B <: Duplicate[T => R] : Duplicable](spore: B, arg: T): R = {
       val dup = summon[Duplicable[B]]
       val duplicated = dup.duplicate(spore)
-      duplicated.unwrap()(arg)
+      duplicated(arg)
     }
 
     val x = new C
@@ -162,7 +162,7 @@ class DuplicableTests {
   @Test
   def testPassingSpore(): Unit = {
     def m2(s: Duplicate[Int => Int], arg: Int): Int = {
-      s.unwrap()(arg)
+      s(arg)
     }
 
     def m1(s: Duplicate[Int => Int]): Int = {
@@ -185,7 +185,7 @@ class DuplicableTests {
     def m2[B <: Duplicate[Int => Int] : Duplicable](spore: B, arg: Int): Int = {
       val dup = summon[Duplicable[B]]
       val duplicated = dup.duplicate(spore)
-      duplicated.unwrap()(arg)
+      duplicated(arg)
     }
 
     def m1[B <: Duplicate[Int => Int] : Duplicable](spore: B): Int = {
@@ -208,7 +208,7 @@ class DuplicableTests {
     def duplicateThenApply[S <: Duplicate[Unit => C] : Duplicable](s: S): C = {
       val dup = summon[Duplicable[S]]
       val duplicated = dup.duplicate(s)
-      duplicated.unwrap().apply(())
+      duplicated(())
     }
 
     val x = new C

--- a/core/shared/src/test/scala/spores/upickle/test/PickleTests.scala
+++ b/core/shared/src/test/scala/spores/upickle/test/PickleTests.scala
@@ -7,7 +7,7 @@ import org.junit.runners.JUnit4
 import upickle.default.*
 
 import spores.{Spore, Reflection, SporeBuilder}
-import spores.given
+import spores.default.given
 
 
 @RunWith(classOf[JUnit4])

--- a/sample/jvm/src/main/scala/spores/sample/Agent.scala
+++ b/sample/jvm/src/main/scala/spores/sample/Agent.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import spores.{Spore, SporeBuilder}
-import spores.given
+import spores.default.given
 
 
 object AppendThree extends SporeBuilder[List[String] => List[String]](

--- a/sample/jvm/src/main/scala/spores/sample/Agent.scala
+++ b/sample/jvm/src/main/scala/spores/sample/Agent.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import spores.{Spore, SporeBuilder}
+import spores.default.*
 import spores.default.given
 
 
@@ -96,8 +96,7 @@ class Agent[T : ReadWriter] (init: T) { self =>
           mailbox.poll() match {
             case ApplyBlock(serialized) =>
               // deserialize
-              val unpickledData = read[Spore[T => T]](serialized)
-              val unpickledSpore = unpickledData.unwrap()
+              val unpickledSpore = read[Spore[T => T]](serialized)
 
               // update state by applying the unpickled spore
               val oldState = state.get()

--- a/sample/jvm/src/main/scala/spores/sample/AutoCaptureExample.scala
+++ b/sample/jvm/src/main/scala/spores/sample/AutoCaptureExample.scala
@@ -2,8 +2,8 @@ package spores.sample
 
 import upickle.default.*
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 
 
 object AutoCaptureExample {

--- a/sample/jvm/src/main/scala/spores/sample/SporeExample.scala
+++ b/sample/jvm/src/main/scala/spores/sample/SporeExample.scala
@@ -1,7 +1,7 @@
 package spores.sample
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.sample.platform.*
 
 

--- a/sample/jvm/src/main/scala/spores/sample/futures/FutureMap.scala
+++ b/sample/jvm/src/main/scala/spores/sample/futures/FutureMap.scala
@@ -6,8 +6,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.collection.concurrent.TrieMap
 
-import spores.{Duplicate, Duplicable}
-import spores.Duplicable.duplicate
+import spores.default.*
+import spores.default.given
 
 
 case class Customer(name: String, customerNo: Int)
@@ -44,7 +44,7 @@ object FutureMap {
       if (infos.nonEmpty) sumAges / infos.size else 0.0f
     }
     val safeSpore = duplicate(spore)
-    Future { safeSpore.unwrap().apply(customers) }
+    Future { safeSpore(customers) }
   }
 
   def main(args: Array[String]): Unit = {

--- a/sample/jvm/src/main/scala/spores/sample/futures/Futures.scala
+++ b/sample/jvm/src/main/scala/spores/sample/futures/Futures.scala
@@ -4,8 +4,8 @@ import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import spores.{Duplicable, Duplicate}
-import spores.Duplicate.given
+import spores.default.*
+import spores.default.given
 
 
 object Futures:
@@ -26,16 +26,12 @@ object Futures:
       val fut2 = fib(n - 2)
 
       // captured variables are passed explicitly to
-      // `apply` method of `Block` object
-      fut1.flatMap(
-        Duplicate.applyWithEnv(fut2) { fut2 => (res1: Int) =>
-          fut2.map(
-            Duplicate.applyWithEnv(res1) {
-              res1 => (res2: Int) => res1 + res2
-            }.unwrap()
-          )
-        }.unwrap()
-      )
+      // `applyWithEnv` method of `Spore` object
+      fut1.flatMap(Duplicate.applyWithEnv(fut2) { fut2 => (res1: Int) =>
+        fut2.map(Duplicate.applyWithEnv(res1) {
+          res1 => (res2: Int) => res1 + res2
+        })
+      })
 
   def main(args: Array[String]): Unit =
     // computes 8th Fibonacci number = 21

--- a/sample/jvm/src/main/scala/spores/sample/futures/ParallelTreeReduction.scala
+++ b/sample/jvm/src/main/scala/spores/sample/futures/ParallelTreeReduction.scala
@@ -6,8 +6,8 @@ import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import spores.{Duplicate, Duplicable}
-import spores.Duplicable.duplicate
+import spores.default.*
+import spores.default.given
 
 
 /**
@@ -69,9 +69,9 @@ object ParallelTreeReduction {
     * environment, is first duplicated. The created future only uses
     * and executes the duplicated block.
     */
-  def safeFuture[R](spore: Duplicate[R]) = {
+  def safeFuture[R](spore: Duplicate[() => R]): Future[R] = {
     val safeSpore = duplicate(spore)
-    Future { safeSpore.unwrap() }
+    Future { safeSpore() }
   }
 
   /** Implements parallel tree reduction using blocks and futures.
@@ -98,11 +98,11 @@ object ParallelTreeReduction {
 
     case Branch(left, data, right) =>
 
-      val leftBlock = Duplicate.applyWithEnv(left) { env =>
+      val leftBlock = Duplicate.applyWithEnv(left) { env => () =>
         parReduce(env)
       }
 
-      val rightBlock = Duplicate.applyWithEnv(right) { env =>
+      val rightBlock = Duplicate.applyWithEnv(right) { env => () =>
         parReduce(env)
       }
 

--- a/sample/shared/src/main/scala/sporks/sample/BuilderExample.scala
+++ b/sample/shared/src/main/scala/sporks/sample/BuilderExample.scala
@@ -1,7 +1,7 @@
 package spores.sample
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.sample.platform.*
 
 


### PR DESCRIPTION
This PR does two things.

(1) It creates a new package `spores.default` where all useful things are exported from a single place. This is better as previously the spores package was polluted with exports.

And (2) it replaces the Spore methods `def apply[T1, R](arg1: T1)(using ev: T <:< (T1 => R)): R` etc. with implicit conversions from a `Spore[T1 => R]` to `Function1[T1, R]` etc. In the previous implementation, a Spore[T1 => R] could not be used where a Function1[T1, R] was expected. With the implicit conversion, this is no longer an issue.